### PR TITLE
Fixed Eigen include paths to point to project Eigen headers

### DIFF
--- a/software/src/soc/flight/FGFS.cpp
+++ b/software/src/soc/flight/FGFS.cpp
@@ -9,8 +9,8 @@ using std::string;
 #include <stdlib.h>		// drand48()
 #include <sys/ioctl.h>
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Geometry>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 using namespace Eigen;
 #include <iostream>
 using std::cout;

--- a/software/src/soc/flight/nav_functions_float.cpp
+++ b/software/src/soc/flight/nav_functions_float.cpp
@@ -26,8 +26,8 @@
 /*     Include Pertinent Header Files */
 
 #include <math.h>
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Geometry>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 using namespace Eigen;
 
 #include "nav_functions_float.hxx"

--- a/software/src/soc/flight/nav_functions_float.hxx
+++ b/software/src/soc/flight/nav_functions_float.hxx
@@ -23,8 +23,8 @@
 
 #pragma once
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Geometry>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 using namespace Eigen;
 
 // Constants


### PR DESCRIPTION
FGFS.cpp, nav_functions_float.cpp, nav_functions_float.hxx were including _eigen/Eigen/*_, but the Eigen headers are located at _Eigen/*_. I modified the includes to point at the RAPTRS project Eigen install location.