### PR TITLE
Serial link

### DIFF
--- a/software/src/fmu/SerialLink.cpp
+++ b/software/src/fmu/SerialLink.cpp
@@ -187,6 +187,9 @@ bool SerialLink::checkReceived()
     } else {
       if (c == _frame_byte) {
         /* frame end */
+        if (_recv_fpos == 1) {
+          // Do nothing
+        } else 
         if (_recv_fpos >= _header_len + _footer_len - 1) {
           /* passed crc check, good packet */
           crc = _recv_crc_16.xmodem(&_recv_buf[1],_recv_fpos - 3);

--- a/software/src/soc/common/SerialLink.cpp
+++ b/software/src/soc/common/SerialLink.cpp
@@ -187,7 +187,9 @@ bool SerialLink::checkReceived()
     } else {
       if (c == _frame_byte) {
         /* frame end */
-        if (_recv_fpos >= _header_len + _footer_len - 1) {
+        if (_recv_fpos == 1) {
+          // Do nothing
+        } else if (_recv_fpos >= _header_len + _footer_len - 1) {
           /* passed crc check, good packet */
           crc = _recv_crc_16.xmodem(&_recv_buf[1],_recv_fpos - 3);
           if (crc == (((unsigned short)_recv_buf[_recv_fpos-1] << 8) | _recv_buf[_recv_fpos - 2])) {


### PR DESCRIPTION
Discovered an issue with the Serial Framing scheme. After flying for several minutes the SOC was getting caught in a loop from which it would not recover, traced the issue to SerialLink::checkReceived(). Specifically, we were seeing the "bad packet" else statement executing with _recv_fpos equal to 1.

The fix is to catch and discard a _frame_byte if _recv_fpos==1. This will re-sync the message buffer on the current frame.